### PR TITLE
Initial logic to remove SQL-style comments.

### DIFF
--- a/R/getSQL.r
+++ b/R/getSQL.r
@@ -42,10 +42,20 @@ getSQL <- function(query=NULL, ...) {
 #' @return the unedited SQL statement.
 getSQLRaw <- function(query) {
 	f <- sqlFile(query)
+    
 	if(is.null(f)) { stop(paste("Cannot find query file for ", query, sep='')) }
 	
 	sql <- scan(f, what="character", sep=';', multi.line=FALSE, 
 				comment.char=c("#"), quiet=TRUE, quote=NULL)
+    
+    sql <- ifelse( grepl("--", sql)
+                  ,substr(sql, 0, regexpr("--", sql)-1 )
+                  ,sql
+                  )
+
 	sql <- paste(sql, collapse=" ")
+
+    sql <- gsub("  ", " ", sql)
+
 	return(sql)
 }


### PR DESCRIPTION
In SQL, comments can be noted in two different ways. This logic
removes the type I use the most which is two dashes "--". Much like a
"#" in R, the double dashes can appear anywhere in a line. From that
point on, the line is considered to be a comment.

Also adds a simple gsub to remove the resulting double spaces in the
returned query which makes it easier for users to read the query.
